### PR TITLE
update boost url

### DIFF
--- a/com.github.powertab.powertabeditor.yml
+++ b/com.github.powertab.powertabeditor.yml
@@ -25,7 +25,7 @@ modules:
       - ./b2 --with-date_time --with-iostreams variant=release link=shared runtime-link=shared -j $FLATPAK_BUILDER_N_JOBS install
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2
+        url: https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.bz2
         sha256: 8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
 
   - name: minizip


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
