### PR TITLE
Reduce the flatpak size

### DIFF
--- a/com.github.powertab.powertabeditor.yml
+++ b/com.github.powertab.powertabeditor.yml
@@ -16,7 +16,12 @@ finish-args:
   - --device=all
   # Jack
   - --filesystem=xdg-run/pipewire-0
-
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - '*.la'
+  - '*.a'
 modules:
   - name: boost
     buildsystem: simple


### PR DESCRIPTION
Remove development-related files to reduce the flatpak size.

The installed size reduced from 148.6 MB to  5.2 MB.

